### PR TITLE
handle empty model files

### DIFF
--- a/lookmlint/lookml.py
+++ b/lookmlint/lookml.py
@@ -211,7 +211,7 @@ class Model:
             includes = [includes]
         self.included_views = [i[: -len('.view')] for i in includes]
         self.name = self.filename[: -len('.model.lkml')]
-        self.explores = [Explore(e, model=self.name) for e in self.data['explores']]
+        self.explores = [Explore(e, model=self.name) for e in self.data.get('explores', [])]
 
     def explore_views(self):
         return [v for e in self.explores for v in e.views]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('readme.md') as f:
 setup(
     name='lookmlint',
     description='Linter for LookML',
-    version='0.2.1',
+    version='0.2.2',
     author='Ryan Tuck',
     author_email='ryan.tuck@warbyparker.com',
     url='https://github.com/WarbyParker/lookmlint',


### PR DESCRIPTION
`lookmlint lint` throws an error if a model file exists without any explores.

For an internal project, I need to fix this to allow for empty model files.

I've created an issue in the meantime to implement this as an optional check: https://github.com/WarbyParker/lookmlint/issues/76