### PR TITLE
add makefile with pypi commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# how to package python projects: https://packaging.python.org/tutorials/packaging-projects/
+
+clear_dist_dir:
+	rm -r dist/*
+
+build_dist: clear_dist_dir
+	python3 setup.py sdist bdist_wheel
+
+deploy_to_test_pypi: build_dist
+	python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+deploy_to_pypi: build_dist
+	python3 -m twine upload dist/*


### PR DESCRIPTION
Every time I want to bump the version and update the python package at pypi.org, I forget what incantations are needed and end up referring back to this: https://packaging.python.org/tutorials/packaging-projects/

This encodes those commands in a `Makefile`.