### PR TITLE
Fixes issue parsing views and models in subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info
 *.swp
+*.pyc
 build/
 dist/


### PR DESCRIPTION
This PR switches from using `os.listdir()` to using `pathlib` to walk any repo directories recursively to get a list of views and models. 

Closes #83 