### PR TITLE
bump version per PR #84

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('readme.md') as f:
 setup(
     name='lookmlint',
     description='Linter for LookML',
-    version='1.0.0',
+    version='1.0.1',
     author='Ryan Tuck',
     author_email='ryan.tuck@warbyparker.com',
     url='https://github.com/WarbyParker/lookmlint',


### PR DESCRIPTION
This bumps the version to `1.0.1` to encapsulate the change introduced in #84 by @clausherther  to provide support for nested dirs in a LookML repo.