### PR TITLE
fix filename parsing for views/models

### DIFF
--- a/lookmlint/lookml.py
+++ b/lookmlint/lookml.py
@@ -1,4 +1,5 @@
 # pylint: disable=invalid-name,missing-docstring,too-few-public-methods,too-many-instance-attributes
+import os
 from pathlib import Path
 
 import attr
@@ -229,14 +230,14 @@ class LookML:
         repo_path = Path(self.lookml_repo_path)
 
         self.models = []
-        for model_file in self._model_file_names():
+        for model_file in self._model_file_paths():
             with open(repo_path.joinpath(model_file)) as f:
-                self.models.append(Model(lkml.load(f), model_file))
+                self.models.append(Model(lkml.load(f), os.path.basename(model_file)))
         self.views = []
-        for view_file in self._view_file_names():
+        for view_file in self._view_file_paths():
             with open(repo_path.joinpath(view_file)) as f:
                 for view_data in lkml.load(f)['views']:
-                    self.views.append(View(view_data, view_file))
+                    self.views.append(View(view_data, os.path.basename(view_file)))
 
         # match explore views with their source views
         for m in self.models:
@@ -252,11 +253,11 @@ class LookML:
         p = Path(self.lookml_repo_path)
         return sorted([str(f.resolve()) for f in p.glob(pattern)])
 
-    def _view_file_names(self):
+    def _view_file_paths(self):
 
         return self._get_files_matching_pattern_recursively('**/*.view.lkml')
 
-    def _model_file_names(self):
+    def _model_file_paths(self):
 
         return self._get_files_matching_pattern_recursively('**/*.model.lkml')
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('readme.md') as f:
 setup(
     name='lookmlint',
     description='Linter for LookML',
-    version='1.0.1',
+    version='1.0.2',
     author='Ryan Tuck',
     author_email='ryan.tuck@warbyparker.com',
     url='https://github.com/WarbyParker/lookmlint',


### PR DESCRIPTION
Support for nested repos was introduced in #84. 

This inadvertently changed the behavior of functions that found all view/model files in the repo to to return fully-qualified paths instead of _just_ returning the filenames. 

The result of this is that `mismatched-view-names` checks were failing when they shouldn't have.

This PR updates those function names to be more explicit, as well as passing in just the base filename (instead of the path) when instantiating `View` and `Model` objects, as expected.

Additionally, it bumps the version.

Closes #86 