### PR TITLE
Cleanly parse data tests

### DIFF
--- a/examples/sample_repo/test.model.lkml
+++ b/examples/sample_repo/test.model.lkml
@@ -38,3 +38,18 @@ explore: inventory_transfers {
     sql_on: ${destination_location.id} = ${inventory_transfers.destination_location_id} ;;
   }
 }
+
+test: something {
+  explore_source: orders {
+    column: id {
+      field: orders.id
+    }
+    filters: {
+      field: order_items.unit_cost_usd
+      value: "100"
+    }
+  }
+  assert: something {
+    expression: ${orders.id} == 123 ;;
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'attrs',
         'click',
-        'lkml==0.1.2',
+        'lkml==0.2.2',
         'pyyaml',
     ],
     packages=['lookmlint'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('readme.md') as f:
 setup(
     name='lookmlint',
     description='Linter for LookML',
-    version='1.0.2',
+    version='1.0.3',
     author='Ryan Tuck',
     author_email='ryan.tuck@warbyparker.com',
     url='https://github.com/WarbyParker/lookmlint',


### PR DESCRIPTION
`lookmlint` would previously fail when trying to parse a `model.lkml` file that contained a [data test](https://docs.looker.com/reference/model-params/test).

The underlying LookML parser - `lkml` - was updated a few months back to [support data test parsing](https://github.com/joshtemple/lkml/pull/29).

This PR bumps the necessary version of `lkml` to accomplish this.

Resolves #89