### PR TITLE
[WIP] attempt to handle manifest files

### DIFF
--- a/lookmlint/lookmlint.py
+++ b/lookmlint/lookmlint.py
@@ -127,7 +127,7 @@ def unused_includes(model):
     # don't suggest any includes are unused
     if model.included_views == ['*']:
         return []
-    explore_view_sources = [v.source_view.name for v in model.explore_views()]
+    explore_view_sources = [v.source_view.name for v in model.explore_views() if v.source_view]
     return sorted(list(set(model.included_views) - set(explore_view_sources)))
 
 


### PR DESCRIPTION
`lookmlint` fails on parsing projects with manifest files due to not being able to find the source views associated with a view that is joined in a given explores.

This is a WIP PR on addressing that problem. It works on the sample repo, but I've noticed at least one check that should fail passes in another repo, so it's definitely not up-to-snuff. Additionally, the patches aren't that elegant.